### PR TITLE
feat(metrics): add configurable latency percentiles

### DIFF
--- a/examples/basic_benchmark.rs
+++ b/examples/basic_benchmark.rs
@@ -24,7 +24,10 @@ async fn main() -> Result<()> {
         (results.successful_requests as f64 / results.total_requests as f64) * 100.0
     );
     println!("Throughput: {:.2} req/s", results.throughput);
-    println!("p99 latency: {:?}", results.latency_p99);
+    println!(
+        "p99 latency: {:?}",
+        results.latency_percentiles.iter().find(|(p, _)| *p == 99.0)
+    );
 
     Ok(())
 }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -98,6 +98,7 @@ pub struct BenchmarkBuilder {
     max_retries: usize,
     show_progress: bool,
     insecure: bool,
+    percentiles: Vec<f64>,
 }
 
 impl BenchmarkBuilder {
@@ -134,6 +135,7 @@ impl BenchmarkBuilder {
             max_retries: 3,
             show_progress: false,
             insecure: false,
+            percentiles: vec![50.0, 90.0, 95.0, 99.9],
         }
     }
 
@@ -564,6 +566,40 @@ impl BenchmarkBuilder {
         self
     }
 
+    /// Set the latency percentiles to compute (default: `[50.0, 90.0, 95.0, 99.0]`).
+    ///
+    /// Accepts any `f64` values in the range `(0.0, 100.0]`. Results are available
+    /// in [`BenchmarkResults::latency_percentiles`] as a `Vec<(f64, Duration)>`,
+    /// ordered by the percentile values provided.
+    ///
+    /// Useful for SLO-sensitive benchmarks that require fine-grained percentiles
+    /// such as p99.9 or p99.99.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use httpress::Benchmark;
+    /// # #[tokio::main]
+    /// # async fn main() -> httpress::Result<()> {
+    /// let results = Benchmark::builder()
+    ///     .url("http://localhost:3000")
+    ///     .requests(10000)
+    ///     .percentiles(vec![50.0, 90.0, 99.0, 99.9])
+    ///     .build()?
+    ///     .run()
+    ///     .await?;
+    ///
+    /// for (p, latency) in &results.latency_percentiles {
+    ///     println!("p{}: {:?}", p, latency);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn percentiles(mut self, percentiles: Vec<f64>) -> Self {
+        self.percentiles = percentiles;
+        self
+    }
+
     /// Build the benchmark.
     ///
     /// Validates the configuration and constructs a [`Benchmark`] ready to run.
@@ -652,6 +688,7 @@ impl BenchmarkBuilder {
             max_retries: self.max_retries,
             progress_fn: None,
             insecure: self.insecure,
+            percentiles: self.percentiles,
         };
 
         let (config, progress_bar) = if self.show_progress {
@@ -744,7 +781,7 @@ impl Benchmark {
     /// let results = benchmark.run().await?;
     ///
     /// println!("Throughput: {:.2} req/s", results.throughput);
-    /// println!("p99 latency: {:?}", results.latency_p99);
+    /// println!("p99 latency: {:?}", results.latency_percentiles.iter().find(|(p, _)| *p == 99.0));
     /// # Ok(())
     /// # }
     /// ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,6 +52,15 @@ pub struct Cli {
     /// Output serialized into provided format
     #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Text)]
     pub output: OutputFormat,
+
+    /// Percentiles to capture
+    #[arg(
+        long,
+        value_name = "percentiles",
+        value_delimiter = ',',
+        default_value = "50.0,90.0,95.0,99.0"
+    )]
+    pub percentiles: Vec<f64>,
 }
 
 #[derive(Subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -508,6 +508,7 @@ pub struct BenchConfig {
     pub max_retries: usize,
     pub progress_fn: Option<ProgressFn>,
     pub insecure: bool,
+    pub percentiles: Vec<f64>,
 }
 
 impl BenchConfig {
@@ -543,6 +544,7 @@ impl BenchConfig {
             max_retries: 3,
             progress_fn: None,
             insecure: args.insecure,
+            percentiles: args.percentiles,
         })
     }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -340,7 +340,7 @@ impl Executor {
 
         let elapsed = start_time.elapsed();
 
-        Ok(metrics.into_results(elapsed))
+        Ok(metrics.into_results(elapsed, &self.config.percentiles))
     }
 
     /// Spawn a rate coordinator task if dynamic rate is configured.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -25,7 +25,7 @@
 //!
 //! // Or access individual metrics
 //! println!("Throughput: {:.2} req/s", results.throughput);
-//! println!("p99 latency: {:?}", results.latency_p99);
+//! println!("p99 latency: {:?}", results.latency_percentiles.iter().find(|(p, _)| *p == 99.0));
 //! println!("Success rate: {:.2}%",
 //!     (results.successful_requests as f64 / results.total_requests as f64) * 100.0
 //! );
@@ -72,7 +72,7 @@ pub struct RequestResult {
 /// println!("Success rate: {:.2}%",
 ///     (results.successful_requests as f64 / results.total_requests as f64) * 100.0
 /// );
-/// println!("p99 latency: {:?}", results.latency_p99);
+/// println!("p99 latency: {:?}", results.latency_percentiles.iter().find(|(p, _)| *p == 99.0));
 /// # Ok(())
 /// # }
 /// ```
@@ -106,21 +106,9 @@ pub struct BenchmarkResults {
     #[serde(serialize_with = "serialize_duration")]
     pub latency_mean: Duration,
 
-    /// 50th percentile (median) request latency.
-    #[serde(serialize_with = "serialize_duration")]
-    pub latency_p50: Duration,
-
-    /// 90th percentile request latency.
-    #[serde(serialize_with = "serialize_duration")]
-    pub latency_p90: Duration,
-
-    /// 95th percentile request latency.
-    #[serde(serialize_with = "serialize_duration")]
-    pub latency_p95: Duration,
-
-    /// 99th percentile request latency.
-    #[serde(serialize_with = "serialize_duration")]
-    pub latency_p99: Duration,
+    /// Mean (average) request latency.
+    #[serde(serialize_with = "serialize_percentile")]
+    pub latency_percentiles: Vec<(f64, Duration)>,
 
     /// Distribution of HTTP status codes and their counts.
     pub status_codes: HashMap<u16, usize>,
@@ -191,13 +179,12 @@ impl BenchmarkResults {
         );
 
         println!("\nLatency:");
-        println!("  Min:    {}", format_duration(self.latency_min));
-        println!("  Max:    {}", format_duration(self.latency_max));
-        println!("  Mean:   {}", format_duration(self.latency_mean));
-        println!("  p50:    {}", format_duration(self.latency_p50));
-        println!("  p90:    {}", format_duration(self.latency_p90));
-        println!("  p95:    {}", format_duration(self.latency_p95));
-        println!("  p99:    {}", format_duration(self.latency_p99));
+        println!("  Min:    {}", format_duration(&self.latency_min));
+        println!("  Max:    {}", format_duration(&self.latency_max));
+        println!("  Mean:   {}", format_duration(&self.latency_mean));
+        for (percentile, duration) in &self.latency_percentiles {
+            println!("  p{}:    {}", percentile, format_duration(duration));
+        }
 
         if !self.status_codes.is_empty() {
             println!("\nStatus codes:");
@@ -348,44 +335,24 @@ impl Metrics {
     }
 
     /// Convert raw metrics into computed results
-    pub fn into_results(mut self, elapsed: Duration) -> BenchmarkResults {
+    pub fn into_results(mut self, elapsed: Duration, percentiles: &[f64]) -> BenchmarkResults {
         self.latencies.sort();
         let sorted = &self.latencies;
 
-        let (
-            latency_min,
-            latency_max,
-            latency_mean,
-            latency_p50,
-            latency_p90,
-            latency_p95,
-            latency_p99,
-        ) = if sorted.is_empty() {
-            (
-                Duration::ZERO,
-                Duration::ZERO,
-                Duration::ZERO,
-                Duration::ZERO,
-                Duration::ZERO,
-                Duration::ZERO,
-                Duration::ZERO,
-            )
+        let (latency_min, latency_max, latency_mean) = if sorted.is_empty() {
+            (Duration::ZERO, Duration::ZERO, Duration::ZERO)
         } else {
             let min = *sorted.first().unwrap();
             let max = *sorted.last().unwrap();
             let sum: Duration = sorted.iter().sum();
             let mean = sum / sorted.len() as u32;
-
-            (
-                min,
-                max,
-                mean,
-                percentile(sorted, 50),
-                percentile(sorted, 90),
-                percentile(sorted, 95),
-                percentile(sorted, 99),
-            )
+            (min, max, mean)
         };
+
+        let latency_percentiles: Vec<(f64, Duration)> = percentiles
+            .iter()
+            .map(|&p| (p, percentile(sorted, p)))
+            .collect();
 
         BenchmarkResults {
             total_requests: self.total,
@@ -396,10 +363,7 @@ impl Metrics {
             latency_min,
             latency_max,
             latency_mean,
-            latency_p50,
-            latency_p90,
-            latency_p95,
-            latency_p99,
+            latency_percentiles,
             status_codes: self.status_codes,
             total_bytes: self.total_bytes,
             latencies: self.latencies,
@@ -413,16 +377,29 @@ impl Default for Metrics {
     }
 }
 
-fn percentile(sorted: &[Duration], p: usize) -> Duration {
-    let idx = (sorted.len() * p / 100).saturating_sub(1).max(0);
-    sorted[idx]
+fn percentile(sorted: &[Duration], p: f64) -> Duration {
+    if sorted.is_empty() {
+        return Duration::ZERO;
+    }
+    let idx = ((sorted.len() as f64 * p / 100.0) - 1.0).max(0.0) as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn serialize_percentile<S: Serializer>(v: &[(f64, Duration)], s: S) -> Result<S::Ok, S::Error> {
+    use serde::ser::SerializeMap;
+    let mut map = s.serialize_map(Some(v.len()))?;
+    for (percentile, duration) in v {
+        let key = format!("p{}", percentile); // Format key to p50 p99 etc.
+        map.serialize_entry(&key, &format_duration(duration))?;
+    }
+    map.end()
 }
 
 fn serialize_duration<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
-    s.serialize_str(&format_duration(*d))
+    s.serialize_str(&format_duration(d))
 }
 
-fn format_duration(d: Duration) -> String {
+fn format_duration(d: &Duration) -> String {
     let micros = d.as_micros();
     if micros < 1000 {
         format!("{}us", micros)
@@ -439,21 +416,24 @@ mod tests {
 
     #[test]
     fn format_duration_microseconds() {
-        assert_eq!(format_duration(Duration::from_micros(500)), "500us");
-        assert_eq!(format_duration(Duration::from_micros(0)), "0us");
-        assert_eq!(format_duration(Duration::from_micros(999)), "999us");
+        assert_eq!(format_duration(&Duration::from_micros(500)), "500us");
+        assert_eq!(format_duration(&Duration::from_micros(0)), "0us");
+        assert_eq!(format_duration(&Duration::from_micros(999)), "999us");
     }
 
     #[test]
     fn format_duration_milliseconds() {
-        assert_eq!(format_duration(Duration::from_micros(1000)), "1.00ms");
-        assert_eq!(format_duration(Duration::from_millis(12)), "12.00ms");
-        assert_eq!(format_duration(Duration::from_micros(999_999)), "1000.00ms");
+        assert_eq!(format_duration(&Duration::from_micros(1000)), "1.00ms");
+        assert_eq!(format_duration(&Duration::from_millis(12)), "12.00ms");
+        assert_eq!(
+            format_duration(&Duration::from_micros(999_999)),
+            "1000.00ms"
+        );
     }
 
     #[test]
     fn format_duration_seconds() {
-        assert_eq!(format_duration(Duration::from_secs(1)), "1.00s");
-        assert_eq!(format_duration(Duration::from_millis(2500)), "2.50s");
+        assert_eq!(format_duration(&Duration::from_secs(1)), "1.00s");
+        assert_eq!(format_duration(&Duration::from_millis(2500)), "2.50s");
     }
 }

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -176,7 +176,21 @@ async fn test_latency_metrics_populated() {
     // Sanity checks
     assert!(results.latency_min <= results.latency_mean);
     assert!(results.latency_mean <= results.latency_max);
-    assert!(results.latency_p50 <= results.latency_p99);
+
+    // Each subsequent percentile must be greater or equal
+    let percentiles = &results.latency_percentiles;
+    for window in percentiles.windows(2) {
+        let (p_lo, d_lo) = window[0];
+        let (p_hi, d_hi) = window[1];
+        assert!(
+            d_lo <= d_hi,
+            "p{} ({:?}) > p{} ({:?}) — percentiles not monotonic",
+            p_lo,
+            d_lo,
+            p_hi,
+            d_hi
+        );
+    }
 }
 
 #[tokio::test]

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -104,16 +104,7 @@ async fn test_json_serialization_has_readable_durations() {
 
     let json: Value = serde_json::to_value(&results).unwrap();
 
-    let duration_fields = [
-        "duration",
-        "latency_min",
-        "latency_max",
-        "latency_mean",
-        "latency_p50",
-        "latency_p90",
-        "latency_p95",
-        "latency_p99",
-    ];
+    let duration_fields = ["duration", "latency_min", "latency_max", "latency_mean"];
 
     for field in duration_fields {
         let val = &json[field];
@@ -122,6 +113,27 @@ async fn test_json_serialization_has_readable_durations() {
             "expected '{}' to be a string, got: {}",
             field,
             val
+        );
+    }
+
+    // Check dynamic field (latency_percentiles)
+    let percentiles = json["latency_percentiles"]
+        .as_object()
+        .expect("latency_percentiles must be an object");
+    assert!(
+        !percentiles.is_empty(),
+        "latency_percentiles should not be empty"
+    );
+    for (_, value) in percentiles {
+        // assert!(
+        //     ke
+        //     "percentile key should be a number, got: {}",
+        //     key
+        // );
+        assert!(
+            value.is_string(),
+            "latency value should be a human-readable string, got: {}",
+            value
         );
     }
 }


### PR DESCRIPTION
Implements:  #13

Replace hardcoded p50/p90/p95/p99 fields with a dynamic `latency_percentiles: Vec<(f64, Duration)>` computed from a user-supplied list of percentile values.

- Add `--percentiles` CLI flag (default: 50,90,95,99)
- Add `BenchmarkBuilder::percentiles()` builder method
- Store percentiles in `BenchConfig` and pass it through to `Metrics::into_results`
- Update `BenchmarkResults::print()` to iterate dynamic percentiles
- Update JSON serialization to output `latency_percentiles` array
- Update behavioral and serialization tests

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes (if applicable)
- [x] I have added comments to my code
- [x] I have added necessary documentation
