### PR TITLE
feat(errors): add detailed error types instead of generic HTTP errors

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -5,13 +5,12 @@ use http_body_util::{BodyExt, Full};
 use hyper::Request;
 use hyper_tls::HttpsConnector;
 use hyper_util::client::legacy::Client;
- use hyper_util::client::legacy::Error as HyperError;
+use hyper_util::client::legacy::Error as HyperError;
 use hyper_util::rt::TokioExecutor;
 
 use crate::config::{BenchConfig, HttpMethod, RequestConfig, RequestContext, RequestSource};
-use crate::error::{Result, Error};
+use crate::error::{Error, Result};
 use std::error::Error as StdError;
-
 
 /// HTTP client wrapper for benchmark requests
 pub struct HttpClient {
@@ -140,8 +139,11 @@ impl HttpClient {
                     "dns",
                     "no such host",
                     "temporary failure in name resolution",
-                    ];
-                if DNS_PATTERNS.iter().any(|pattern| io_err_msg.contains(pattern)){
+                ];
+                if DNS_PATTERNS
+                    .iter()
+                    .any(|pattern| io_err_msg.contains(pattern))
+                {
                     return Error::DnsError;
                 }
                 return match io_err.kind() {
@@ -149,7 +151,6 @@ impl HttpClient {
                     std::io::ErrorKind::ConnectionReset => Error::ConnectionReset,
                     std::io::ErrorKind::TimedOut => Error::Timeout,
                     _ => Error::Other(io_err.to_string()),
-
                 };
             }
             source = err.source();

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,10 +5,13 @@ use http_body_util::{BodyExt, Full};
 use hyper::Request;
 use hyper_tls::HttpsConnector;
 use hyper_util::client::legacy::Client;
+ use hyper_util::client::legacy::Error as HyperError;
 use hyper_util::rt::TokioExecutor;
 
 use crate::config::{BenchConfig, HttpMethod, RequestConfig, RequestContext, RequestSource};
-use crate::error::Result;
+use crate::error::{Result, Error};
+use std::error::Error as StdError;
+
 
 /// HTTP client wrapper for benchmark requests
 pub struct HttpClient {
@@ -99,8 +102,10 @@ impl HttpClient {
 
         let response = tokio::time::timeout(self.timeout, self.client.request(request))
             .await
-            .map_err(|_| crate::error::Error::Timeout)?
-            .map_err(|e| crate::error::Error::Http(e.into()))?;
+            //.map_err(|_| crate::error::Error::Timeout)?
+            //.map_err(|e| crate::error::Error::Http(e.into()))?;
+            .map_err(|_| Error::Timeout)?
+            .map_err(|e| self.classify_error(e))?;
 
         let status = response.status().as_u16();
 
@@ -117,5 +122,47 @@ impl HttpClient {
         };
 
         Ok((Some(status), bytes))
+    }
+    fn classify_error(&self, err: HyperError) -> Error {
+        let mut source = err.source();
+        while let Some(err) = source {
+            // TLS Errors Check (native_tls)
+            if let Some(tls_err) = err.downcast_ref::<native_tls::Error>() {
+                return Error::TlsError(tls_err.to_string());
+            }
+            // IO Errors Check
+            if let Some(io_err) = err.downcast_ref::<std::io::Error>() {
+                let io_err_msg = io_err.to_string().to_lowercase();
+                // DNS Error - Check
+                const DNS_PATTERNS: &[&str] = &[
+                    "failed to lookup address information",
+                    "name or service not known",
+                    "dns",
+                    "no such host",
+                    "temporary failure in name resolution",
+                    ];
+                if DNS_PATTERNS.iter().any(|pattern| io_err_msg.contains(pattern)){
+                    return Error::DnsError;
+                }
+                return match io_err.kind() {
+                    std::io::ErrorKind::ConnectionRefused => Error::ConnectionRefused,
+                    std::io::ErrorKind::ConnectionReset => Error::ConnectionReset,
+                    std::io::ErrorKind::TimedOut => Error::Timeout,
+                    _ => Error::Other(io_err.to_string()),
+
+                };
+            }
+            source = err.source();
+        }
+        let err_msg = err.to_string().to_lowercase();
+        // Hyper Error - Common Errors Check
+        if err_msg.contains("connection reset") {
+            return Error::ConnectionReset;
+        }
+        if err_msg.contains("connection refused") {
+            return Error::ConnectionRefused;
+        }
+        // Generic HTTP Error
+        Error::Http(Box::new(err))
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -101,8 +101,6 @@ impl HttpClient {
 
         let response = tokio::time::timeout(self.timeout, self.client.request(request))
             .await
-            //.map_err(|_| crate::error::Error::Timeout)?
-            //.map_err(|e| crate::error::Error::Http(e.into()))?;
             .map_err(|_| Error::Timeout)?
             .map_err(|e| self.classify_error(e))?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,42 @@ pub enum Error {
     /// This wraps standard I/O errors.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// Connection was refused by the target server.
+    ///
+    /// This occurs when the server is not listening on the specified port,
+    /// a firewall is blocking the connection, or the host is unreachable.
+    #[error("Connection refused")]
+    ConnectionRefused,
+
+    /// DNS resolution failed for the target hostname.
+    ///
+    /// This occurs when the hostname cannot be resolved to an IP address,
+    /// possibly due to an invalid hostname, DNS server issues, or network problems.
+    #[error("DNS resolution failed")]
+    DnsError,
+
+    /// TLS/SSL handshake failed.
+    ///
+    /// This occurs when the server's TLS certificate is invalid, self-signed,
+    /// expired, or there's a protocol version mismatch.
+    #[error("TLS handshake failed: {0}")]
+    TlsError(String),
+
+    /// Connection was reset by the server or an intermediate device.
+    ///
+    /// This occurs when the connection is unexpectedly closed, possibly due to
+    /// server load balancers dropping connections, network issues, or server crashes.
+    #[error("Connection reset")]
+    ConnectionReset,
+
+
+    /// Uncategorized error occurred.
+    ///
+    /// This is a catch-all for errors that don't fit into other categories.
+    /// The error message contains details about what went wrong.
+    #[error("Error: {0}")]
+    Other(String),
 }
 
 /// Result type alias for httpress operations.

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,7 +104,6 @@ pub enum Error {
     #[error("Connection reset")]
     ConnectionReset,
 
-
     /// Uncategorized error occurred.
     ///
     /// This is a catch-all for errors that don't fit into other categories.

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -47,6 +47,7 @@ impl WorkerContext {
                             latency: Duration::ZERO,
                             status: None,
                             bytes: 0,
+                            error: None,
                         };
                     }
                     HookAction::Retry => {
@@ -59,6 +60,7 @@ impl WorkerContext {
                                 latency: Duration::ZERO,
                                 status: None,
                                 bytes: 0,
+                                error: None,
                             };
                         }
                     }
@@ -66,11 +68,15 @@ impl WorkerContext {
             }
 
             let start = Instant::now();
-            let (status, bytes) = self
+            let (status, bytes, error) = match self
                 .client
                 .execute_for_worker(&self.config, self.worker_id, request_number)
                 .await
-                .unwrap_or_default();
+                //.unwrap_or_default();
+                {
+                    Ok((status, bytes)) => (status, bytes, None),
+                    Err(e) => (None, 0, Some(e))
+                };
             let latency = start.elapsed();
 
             // Execute after_request hooks
@@ -88,6 +94,7 @@ impl WorkerContext {
                         latency,
                         status,
                         bytes,
+                        error,
                     };
                 }
                 HookAction::Abort => {
@@ -96,6 +103,7 @@ impl WorkerContext {
                         latency,
                         status: None,
                         bytes: 0,
+                        error: None,
                     };
                 }
                 HookAction::Retry => {
@@ -108,6 +116,7 @@ impl WorkerContext {
                             latency,
                             status,
                             bytes,
+                            error,
                         };
                     }
                 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -72,11 +72,10 @@ impl WorkerContext {
                 .client
                 .execute_for_worker(&self.config, self.worker_id, request_number)
                 .await
-                //.unwrap_or_default();
-                {
-                    Ok((status, bytes)) => (status, bytes, None),
-                    Err(e) => (None, 0, Some(e))
-                };
+            {
+                Ok((status, bytes)) => (status, bytes, None),
+                Err(e) => (None, 0, Some(e)),
+            };
             let latency = start.elapsed();
 
             // Execute after_request hooks

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -37,12 +37,14 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use serde::{Serialize, Serializer};
+use crate::error::Error;
 
 /// Result of a single HTTP request
 pub struct RequestResult {
     pub latency: Duration,
     pub status: Option<u16>,
     pub bytes: usize,
+    pub error: Option<Error>,
 }
 
 /// Computed benchmark results with detailed metrics.
@@ -119,6 +121,8 @@ pub struct BenchmarkResults {
     /// Raw latency data for histogram computation (not serialized).
     #[serde(skip)]
     latencies: Vec<Duration>,
+
+    pub errors: HashMap<String, usize>,
 }
 
 impl BenchmarkResults {
@@ -192,6 +196,15 @@ impl BenchmarkResults {
             codes.sort_by_key(|(k, _)| *k);
             for (code, count) in codes {
                 println!("  {}: {}", code, count);
+            }
+        }
+        // Print Errors
+        if !self.errors.is_empty() {
+            println!("\nErrors:\n");
+            let mut errors: Vec<_> = self.errors.iter().collect();
+            errors.sort_by_key(|(_, count)|std::cmp::Reverse(*count));
+            for (error_type, count) in errors {
+                println!("  {}: {}", error_type, count);
             }
         }
     }
@@ -292,6 +305,7 @@ pub struct Metrics {
     pub latencies: Vec<Duration>,
     pub status_codes: HashMap<u16, usize>,
     pub total_bytes: u64,
+    pub errors: HashMap<String, usize>,
 }
 
 /// Maximum width for histogram bars in ASCII display
@@ -309,6 +323,7 @@ impl Metrics {
             latencies: Vec::new(),
             status_codes: HashMap::new(),
             total_bytes: 0,
+            errors: HashMap::new(),
         }
     }
 
@@ -319,6 +334,7 @@ impl Metrics {
             latencies: Vec::with_capacity(capacity),
             status_codes: HashMap::new(),
             total_bytes: 0,
+            errors: HashMap::new(),
         }
     }
 
@@ -330,6 +346,9 @@ impl Metrics {
             if (200..300).contains(&status) {
                 self.success += 1;
             }
+        }
+        if let Some(err) = &result.error {
+            *self.errors.entry(err.to_string()).or_insert(0) += 1;
         }
         self.latencies.push(result.latency);
     }
@@ -367,6 +386,7 @@ impl Metrics {
             status_codes: self.status_codes,
             total_bytes: self.total_bytes,
             latencies: self.latencies,
+            errors: self.errors,
         }
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -36,8 +36,8 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use serde::{Serialize, Serializer};
 use crate::error::Error;
+use serde::{Serialize, Serializer};
 
 /// Result of a single HTTP request
 pub struct RequestResult {
@@ -202,7 +202,7 @@ impl BenchmarkResults {
         if !self.errors.is_empty() {
             println!("\nErrors:\n");
             let mut errors: Vec<_> = self.errors.iter().collect();
-            errors.sort_by_key(|(_, count)|std::cmp::Reverse(*count));
+            errors.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
             for (error_type, count) in errors {
                 println!("  {}: {}", error_type, count);
             }

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -21,6 +21,8 @@ async fn test_connection_refused() {
     assert_eq!(results.total_requests, 5);
     assert_eq!(results.failed_requests, 5);
     assert_eq!(results.successful_requests, 0);
+    //Confirms if "Connection refused" is classified
+    assert_eq!(results.errors.get("Connection refused").copied(), Some(5));
 }
 
 #[tokio::test]
@@ -48,6 +50,8 @@ async fn test_request_timeout() {
         "Latency max {:?} should be less than 500ms",
         results.latency_max
     );
+    // Confirms if "Request timeout" is classified
+    assert_eq!(results.errors.get("Request timeout").copied(), Some(3));
 }
 
 #[tokio::test]
@@ -208,6 +212,10 @@ async fn test_dns_error() {
     assert_eq!(results.total_requests, 3);
     assert_eq!(results.failed_requests, 3);
     assert_eq!(results.successful_requests, 0);
+    assert_eq!(
+        results.errors.get("DNS resolution failed").copied(),
+        Some(3)
+    );
 }
 
 #[tokio::test]
@@ -225,21 +233,11 @@ async fn test_tls_error() {
     assert_eq!(results.total_requests, 3);
     assert_eq!(results.failed_requests, 3);
     assert_eq!(results.successful_requests, 0);
-}
-
-#[tokio::test]
-async fn test_connection_refused_classification() {
-    let results = Benchmark::builder()
-        .url("http://127.0.0.1:59998/") // No server on this port
-        .requests(3)
-        .concurrency(1)
-        .build()
-        .unwrap()
-        .run()
-        .await
-        .unwrap();
-
-    assert_eq!(results.total_requests, 3);
-    assert_eq!(results.failed_requests, 3);
-    assert_eq!(results.successful_requests, 0);
+    assert!(
+        results
+            .errors
+            .keys()
+            .any(|k| k.contains("TLS handshake failed")),
+        "Expected TLS handshake failed error"
+    );
 }

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -192,3 +192,54 @@ async fn test_throughput_calculated() {
         calculated_throughput
     );
 }
+
+#[tokio::test]
+async fn test_dns_error() {
+    let results = Benchmark::builder()
+        .url("http://this-domain-definitely-does-not-exist-12345.com") // Invalid domain
+        .requests(3)
+        .concurrency(1)
+        .build()
+        .unwrap()
+        .run()
+        .await
+        .unwrap();
+
+    assert_eq!(results.total_requests, 3);
+    assert_eq!(results.failed_requests, 3);
+    assert_eq!(results.successful_requests, 0);
+}
+
+#[tokio::test]
+async fn test_tls_error() {
+    let results = Benchmark::builder()
+        .url("https://expired.badssl.com") // Invalid TLS certificate
+        .requests(3)
+        .concurrency(1)
+        .build()
+        .unwrap()
+        .run()
+        .await
+        .unwrap();
+
+    assert_eq!(results.total_requests, 3);
+    assert_eq!(results.failed_requests, 3);
+    assert_eq!(results.successful_requests, 0);
+}
+
+#[tokio::test]
+async fn test_connection_refused_classification() {
+    let results = Benchmark::builder()
+        .url("http://127.0.0.1:59998/") // No server on this port
+        .requests(3)
+        .concurrency(1)
+        .build()
+        .unwrap()
+        .run()
+        .await
+        .unwrap();
+
+    assert_eq!(results.total_requests, 3);
+    assert_eq!(results.failed_requests, 3);
+    assert_eq!(results.successful_requests, 0);
+}


### PR DESCRIPTION
# Task
Add Detailed Error Types instead of Generic HTTP Errors

# Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

# Description
Add specific error variants (ConnectionRefused, DnsError, TlsError, ConnectionReset, Other) to help users diagnose problems faster.

Previously, all transport errors were wrapped in Error::Http, making it impossible to distinguish between DNS failures, TLS errors, connection issues, etc.

Changes:
- Add 5 new error variants in src/error.rs
- Implement error classification in HttpClient.classify_error()
- Track error type counts in metrics
- Display error breakdown in CLI output
- Add tests for DNS, TLS, and connection refused errors

Fixes #8 

# Demo

Sample Screenshot for Connection Refused:
<img width="934" height="622" alt="image" src="https://github.com/user-attachments/assets/42d3ad90-2688-4fc3-b55a-94e3bdcceaa5" />


# Checklist

- [ x] I have performed a self-review of my own code
- [ x] I have added tests to cover my changes (if applicable)
- [x ] I have added comments to my code
- [ ] I have added necessary documentation
