### PR TITLE
feat: add step ramp rate control example

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ The `examples/` directory contains:
 - [basic_benchmark.rs](examples/basic_benchmark.rs) - basic benchmark example
 - [custom_requests.rs](examples/custom_requests.rs) - dynamic request generation using `request_fn`
 - [rate_ramping.rs](examples/rate_ramping.rs) - advanced rate control using `rate_fn`
+- [step_ramp.rs](examples/step_ramp.rs) - stepped rate control that holds each level before jumping to the next using `rate_fn`
 - [hooks_metrics.rs](examples/hooks_metrics.rs) - custom metrics collection using hooks
 - [test_server.rs](examples/test_server.rs) - local axum test server used by the other examples
 

--- a/examples/step_ramp.rs
+++ b/examples/step_ramp.rs
@@ -1,0 +1,35 @@
+use httpress::{Benchmark, RateContext};
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> httpress::Result<()> {
+    println!("Step Ramp Rate Example");
+    println!("======================\n");
+    println!("This benchmark holds a fixed rate for a few seconds, then jumps");
+    println!("to the next level: 100 -> 200 -> 300 req/s.\n");
+
+    // Each rate level (req/s) is held for `secs_per_step` seconds before
+    // stepping up to the next one. The final level is held until the benchmark ends.
+    let rate_steps = [100.0, 200.0, 300.0];
+    let secs_per_step = 5.0;
+    let total_duration = Duration::from_secs_f64(secs_per_step * rate_steps.len() as f64);
+
+    let results = Benchmark::builder()
+        .url("http://localhost:3000")
+        .concurrency(50)
+        .duration(total_duration)
+        .show_progress(true)
+        .rate_fn(move |ctx: RateContext| {
+            // Select the current step from how much time has elapsed, clamping
+            // to the last step so we never index past the end.
+            let step = (ctx.elapsed.as_secs_f64() / secs_per_step) as usize;
+            rate_steps[step.min(rate_steps.len() - 1)]
+        })
+        .build()?
+        .run()
+        .await?;
+
+    results.print();
+
+    Ok(())
+}


### PR DESCRIPTION
# Task

Issue [#7](https://github.com/GabrielTecuceanu/httpress/issues/7)

# Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

# Description

Adds a new `step_ramp` example, addressing the first `rate_fn` item requested
in #7 (step ramp).

- **`examples/step_ramp.rs`** — demonstrates stepped rate control using
  `rate_fn`: the benchmark holds a fixed rate for a set duration, then jumps to
  the next level (100 → 200 → 300 req/s), clamping to the final level until the
  run ends. It complements the existing `rate_ramping.rs` (which ramps
  *linearly*) by showing the discrete-step pattern instead.
- **`README.md`** — links the new example under the Examples section.

No library/API changes — this is example + docs only, and it runs against the
existing `examples/test_server.rs` with no new routes required.

This is a partial implementation of #7 (one of the five listed examples); the
issue notes partial PRs are accepted and should remain open for the rest.

Contributes to #7

# Demo

$ cargo run --example test_server   # in one terminal
$ cargo run --example step_ramp     # in another

Step Ramp Rate Example

This benchmark holds a fixed rate for a few seconds, then jumps
to the next level: 100 -> 200 -> 300 req/s.

--- Benchmark Complete ---
Requests:     1311 total, 1311 success, 0 errors
Duration:     15.36s
...
Status codes:
  200: 1311

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes (if applicable) — N/A: examples are compile-checked by CI (`cargo build --examples`); no unit tests apply
- [x] I have added comments to my code
- [x] I have added necessary documentation

# Aditional context

Verified locally against the full CONTRIBUTING checklist:

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- `cargo test --all-features` — all pass
- Ran end-to-end against `examples/test_server.rs` — steps through the full
  duration and completes with all 200s